### PR TITLE
Add support for failure element based on xunit xml format

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ Given a test with title 'test should behave like so @aid=EPM-DP-C1234 @sid=EPM-1
 <test name="test should behave like so" aid="EPM-DP-C1234" sid="EPM-1234" type="Integration" />
 ```
 
+## XUnit XML format
+The generated test results file conforms to [XUnit's XML format](https://xunit.net/docs/format-xml-v2).
+
+### `failure` element
+In case of an error or failure during a test run, a `failure` element will be included as a child element with its corresponding `test` element. This element will contain information about the failed test.
+
+```
+<failure exception-type="Error">
+  <message><![CDATA[This test threw an error]]></message>
+  <stack-trace><![CDATA[Error: testing123
+at Context.<anonymous> (example.spec.ts-1:1:1)]]></stack-trace>
+</failure>
+```
+
 ### Full configuration options
 
 | Parameter | Effect |

--- a/index.js
+++ b/index.js
@@ -28,13 +28,6 @@ function configureDefaults(options) {
   return options;
 }
 
-function isInvalidSuite(suite) {
-  return (
-    (!suite.root && suite.title === '') ||
-    (suite.tests.length === 0 && suite.suites.length === 0)
-  );
-}
-
 /**
  * Parses title for tags in format @tagName=value
  * @param {} testTitle
@@ -103,7 +96,7 @@ function MochaXUnitReporter(runner, options) {
   this._runner.on(
     'suite',
     function(suite) {
-      if (!isInvalidSuite(suite)) {
+      if (suite.tests.length) {
         collections.push(this.getCollectionData(suite));
       }
     }.bind(this)
@@ -151,7 +144,7 @@ MochaXUnitReporter.prototype.getCollectionData = function(suite) {
     collection: [
       {
         _attr: {
-          name: suite.title || 'Root Suite',
+          name: suite.title || 'Untitled Collection',
           total: suite.tests.length
         }
       }
@@ -209,6 +202,28 @@ MochaXUnitReporter.prototype.getTestData = function(test, status) {
           }
         }
       });
+    });
+  }
+
+  if (status === 'failed') {
+    testCase.test.push({
+      failure: [
+        {
+          _attr: {
+            'exception-type': test.err.name
+          }
+        },
+        {
+          message: {
+            _cdata: test.err.message
+          }
+        },
+        {
+          'stack-trace': {
+            _cdata: test.err.stack
+          }
+        }
+      ]
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-xunit-reporter",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A Mocha xunit reporter",
   "main": "index.js",
   "scripts": {

--- a/test/helpers/mock-test.js
+++ b/test/helpers/mock-test.js
@@ -1,12 +1,18 @@
 'use strict';
 
-function Test(fullTitle, title, duration) {
-  return {
+function Test(fullTitle, title, duration, err) {
+  var test = {
     title: title,
     duration: duration,
     fullTitle: function() { return fullTitle; },
     slow: function() {}
   };
+
+  if (err) {
+    test[err] = err;
+  }
+
+  return test;
 }
 
 module.exports = Test;

--- a/test/mocha-xunit-reporter-spec.js
+++ b/test/mocha-xunit-reporter-spec.js
@@ -41,21 +41,30 @@ describe('mocha-xunit-reporter', () => {
     }
 
     runner.fail(
-      new Test('Bar can narfle the garthog', 'can narfle the garthog', 1),
+      new Test('Bar can narfle the garthog', 'can narfle the garthog', 1, {
+        name: 'BarError',
+        message: 'expected garthog to be dead',
+        stack: 'expected garthog to be dead'
+      }),
       {
-        stack:
-          options.invalidChar +
-          'expected garthog to be dead' +
-          options.invalidChar
+        name: 'BarError',
+        message: 'expected garthog to be dead',
+        stack: 'expected garthog to be dead'
       }
     );
 
     runner.fail(
-      new Test('Baz can behave like a flandip', 'can behave like a flandip', 1),
+      new Test('Baz can behave like a flandip', 'can behave like a flandip', 1, {
+        name: 'BazError',
+        message:
+          'expected baz to be masher, a hustler, an uninvited grasper of cone',
+        stack: 'BazFile line:1\nBazFile line:2'
+      }),
       {
         name: 'BazError',
         message:
-          'expected baz to be masher, a hustler, an uninvited grasper of cone'
+          'expected baz to be masher, a hustler, an uninvited grasper of cone',
+        stack: 'BazFile line:1\nBazFile line:2'
       }
     );
 
@@ -234,8 +243,8 @@ describe('mocha-xunit-reporter', () => {
       reporter = spyingReporter();
     });
 
-    it('skips suites with empty title', function() {
-      runner.startSuite({ title: '', tests: [1] });
+    it('skips suites with empty tests', function() {
+      runner.startSuite({ title: '', tests: [] });
       runner.end();
 
       expect(assembly).to.be.empty;
@@ -249,7 +258,7 @@ describe('mocha-xunit-reporter', () => {
     });
 
     it('does not skip suites with nested suites', function() {
-      runner.startSuite({ title: 'test me', suites: [1] });
+      runner.startSuite({ title: 'test me', suites: [1], tests: [1] });
       runner.end();
 
       expect(assembly).to.have.length(1);
@@ -263,18 +272,18 @@ describe('mocha-xunit-reporter', () => {
     });
 
     it('does not skip root suite', function() {
-      runner.startSuite({ title: '', root: true, suites: [1] });
+      runner.startSuite({ title: '', root: true, suites: [1], tests: [1] });
       runner.end();
 
       expect(assembly).to.have.length(1);
     });
 
     it('uses "Root Suite" by default', function() {
-      runner.startSuite({ title: '', root: true, suites: [1] });
+      runner.startSuite({ title: '', root: true, suites: [1], tests: [1] });
       runner.end();
       expect(assembly[0].collection[0]._attr).to.have.property(
         'name',
-        'Root Suite'
+        'Untitled Collection'
       );
     });
 

--- a/test/mock-results.js
+++ b/test/mock-results.js
@@ -51,6 +51,23 @@ module.exports = function(stats, options) {
                       time: '0.001',
                       result: 'failed'
                     }
+                  },
+                  {
+                    failure: [
+                      {
+                        _attr: {
+                          'exception-type': 'BarError'
+                        }
+                      },
+                      {
+                        message: 'expected garthog to be dead'
+                      },
+                      {
+                        'stack-trace': {
+                          _cdata: 'expected garthog to be dead'
+                        }
+                      }
+                    ]
                   }
                 ]
               },
@@ -62,6 +79,23 @@ module.exports = function(stats, options) {
                       time: '0.001',
                       result: 'failed'
                     }
+                  },
+                  {
+                    failure: [
+                      {
+                        _attr: {
+                          'exception-type': 'BazError'
+                        }
+                      },
+                      {
+                        message: 'expected baz to be masher, a hustler, an uninvited grasper of cone'
+                      },
+                      {
+                        'stack-trace': {
+                          _cdata: 'BazFile line:1\nBazFile line:2'
+                        }
+                      }
+                    ]
                   }
                 ]
               }


### PR DESCRIPTION
Test results XML currently does not output the failure element, which is critical for knowing why a test fails. Please check https://xunit.net/docs/format-xml-v2#failure