### PR TITLE
Fix bug where error occurs when there is failure in before/after hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ function configureDefaults(options) {
   return options;
 }
 
-function isInvalidSuite(suite) {
-  return (
+function isValidSuite(suite) {
+  return !(
     (!suite.root && suite.title === '') ||
     (suite.tests.length === 0 && suite.suites.length === 0)
   );
@@ -103,7 +103,7 @@ function MochaXUnitReporter(runner, options) {
   this._runner.on(
     'suite',
     function(suite) {
-      if (!isInvalidSuite(suite)) {
+      if (isValidSuite(suite)) {
         collections.push(this.getCollectionData(suite));
       }
     }.bind(this)

--- a/index.js
+++ b/index.js
@@ -28,6 +28,13 @@ function configureDefaults(options) {
   return options;
 }
 
+function isInvalidSuite(suite) {
+  return (
+    (!suite.root && suite.title === '') ||
+    (suite.tests.length === 0 && suite.suites.length === 0)
+  );
+}
+
 /**
  * Parses title for tags in format @tagName=value
  * @param {} testTitle
@@ -96,7 +103,7 @@ function MochaXUnitReporter(runner, options) {
   this._runner.on(
     'suite',
     function(suite) {
-      if (suite.tests.length) {
+      if (!isInvalidSuite(suite)) {
         collections.push(this.getCollectionData(suite));
       }
     }.bind(this)
@@ -144,7 +151,7 @@ MochaXUnitReporter.prototype.getCollectionData = function(suite) {
     collection: [
       {
         _attr: {
-          name: suite.title || 'Untitled Collection',
+          name: suite.title || 'Root Suite',
           total: suite.tests.length
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-xunit-reporter",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A Mocha xunit reporter",
   "main": "index.js",
   "scripts": {

--- a/test/mocha-xunit-reporter-spec.js
+++ b/test/mocha-xunit-reporter-spec.js
@@ -283,7 +283,24 @@ describe('mocha-xunit-reporter', () => {
       runner.end();
       expect(assembly[0].collection[0]._attr).to.have.property(
         'name',
-        'Untitled Collection'
+        'Root Suite'
+      );
+    });
+
+    it('uses "Root Suite" even with no test when before hook fails', function() {
+      runner.startSuite({ title: '', root: true, suites: [1], tests: [] });
+      runner.fail({
+        fullTitle: () => 'before all hook',
+      }, 'failed');
+      runner.end();
+
+      expect(assembly[0].collection[0]._attr).to.have.property(
+        'name',
+        'Root Suite'
+      );
+      expect(assembly[0].collection[1].test[0]._attr).to.have.property(
+        'result',
+        'failed'
       );
     });
 


### PR DESCRIPTION
This fixes an issue that one user reported where an assert failure or error in before/after hook can cause mocha-xunit-reporter to throw an error