### PR TITLE
Add support for mocharc files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # mocha-xunit-reporter
+
 A Mocha xunit reporter. Produces XUnit-style XML test results.
-Adapted from and Inspired by [mocha-junit-reporter](https://github.com/michaelleeallen/mocha-junit-reporter)
+Adapted from and Inspired by [mocha-junit-reporter](https://github.com/michaelleeallen/mocha-junit-reporter).
 
 ## Installation
+
 ```
 $ npm install mocha-xunit-reporter --save-dev
 ```
@@ -12,54 +14,29 @@ $ npm install -g mocha-xunit-reporter
 ```
 
 ## Usage
+
 Run mocha with `mocha-xunit-reporter`:
 ```
 $ mocha test --reporter mocha-xunit-reporter
 ```
-This will output a results file at `./test-results.xml`.
-
-You may optionally declare an alternate location for rexults XML file by setting the environment variable `MOCHA_FILE` or specifying `mochaFile` in `reporterOptions`:
-```
-$ MOCHA_FILE=./path_to_your/file.xml mocha test --reporter mocha-xunit-reporter
-```
-or
-```
-$ mocha test --reporter mocha-xunit-reporter --reporter-options mochaFile=./path_to_your/file.xml
-```
-or
-```
-var mocha = new Mocha({
-    reporter: 'mocha-xunit-reporter',
-    reporterOptions: {
-        mochaFile: './path_to_your/file.xml'
-    }
-});
+or, in `.mocharc.json` (or the exported object from `.mocharc.js`):
+```json
+{
+    "reporter": "mocha-xunit-reporter",
+    ...
+}
 ```
 
-### `addTags` option
-- If set to true, will parse the test title for tags in format `@tagName=tagValue` and will add them as attribute of the test XML element. It will also clean the outputted tags from the test name XML attribute.
-- See example below:
-```
-var mocha = new Mocha({
-    reporter: 'mocha-xunit-reporter',
-    reporterOptions: {
-        mochaFile: './path_to_your/file.xml',
-        addTags: true
-    }
-});
-```
-Given a test with title 'test should behave like so @aid=EPM-DP-C1234 @sid=EPM-1234 @type=Integration', the outputted test element will look as follows:
-```
-<test name="test should behave like so" aid="EPM-DP-C1234" sid="EPM-1234" type="Integration" />
-```
+## Output
 
-## XUnit XML format
+### Format
+
 The generated test results file conforms to [XUnit's XML format](https://xunit.net/docs/format-xml-v2).
 
 ### `failure` element
 In case of an error or failure during a test run, a `failure` element will be included as a child element with its corresponding `test` element. This element will contain information about the failed test.
 
-```
+```xml
 <failure exception-type="Error">
   <message><![CDATA[This test threw an error]]></message>
   <stack-trace><![CDATA[Error: testing123
@@ -67,12 +44,88 @@ at Context.<anonymous> (example.spec.ts-1:1:1)]]></stack-trace>
 </failure>
 ```
 
-### Full configuration options
+[More information](https://xunit.net/docs/format-xml-v2#failure) about the `failure` element.
 
-| Parameter | Effect |
-| --------- | ------ |
-| mochaFile | configures the file to write reports to |
-| includePending | if set to a truthy value pending tests will be included in the report |
-| toConsole | if set to a truthy value the produced XML will be logged to the console |
-| assemblyName | the name for the assembly element. (defaults to 'Mocha Tests') |
-| addTags | if set to a truthy value will parse the test title for tags |
+
+## Configuration
+
+Configuration options (all optional):
+
+| Parameter | Type | Effect |
+| --------- | ---- | ------ |
+| `mochaFile` | string | configures the file to write reports to |
+| `includePending` | boolean | if set to a truthy value pending tests will be included in the report |
+| `toConsole` | boolean | if set to a truthy value the produced XML will be logged to the console |
+| `assemblyName` | string | the name for the assembly element. (defaults to 'Mocha Tests') |
+| `addTags` | boolean | if set to a truthy value will parse the test title for tags |
+
+### Specifying Reporter Options
+
+In general, configuration options may be specified any of the following ways. There may be additional ways to specify individual options (see below).
+
+- Command-line reporter options; e.g.
+    ```js
+    $ mocha test --reporter mocha-xunit-reporter --reporter-options mochaFile=./path_to_your/file.xml
+    ```
+
+- Mocha constructor `reporterOptions`; e.g.
+    ```js
+    var mocha = new Mocha({
+        reporter: 'mocha-xunit-reporter',
+        reporterOptions: {
+            mochaFile: './path_to_your/file.xml'
+        }
+    });
+    ```
+
+- `.mocharc.js`/`.mocharc.json`:
+    ```json
+    {
+        "reporter": "mocha-xunit-reporter",
+        "reporterOptions": {
+            "mochaFile": "./path_to_your/file.xml"
+        }
+    }
+    ```
+
+Details about some configuration options are included below.
+
+---
+
+### `mochaFile` or `MOCHA_FILE`
+
+The generated test results file conforms to [XUnit's XML format](https://xunit.net/docs/format-xml-v2).
+
+Default location: `./test-results.xml`
+
+This option may additionally be specified by the environment variable `MOCHA_FILE`:
+
+```js
+$ MOCHA_FILE=./path_to_your/file.xml mocha test --reporter mocha-xunit-reporter
+```
+
+#### Magic filename
+
+If the string `[hash]` is present in the received file path, it will be replaced with an MD5 hash of the output XML.
+
+For example, for this received file path:
+```
+test-results.[hash].xml
+```
+...the output file might be `test-results.320ae2121e02b35c30dc16b8b7a2215e.xml`
+
+### `addTags`
+
+If set to true, will parse the test title for tags in format `@tagName=tagValue` and will add them as attribute of the test XML element. It will also clean the outputted tags from the test name XML attribute.
+
+#### Example behavior:
+
+Consider a test with this title:
+```js
+'test should behave like so @aid=EPM-DP-C1234 @sid=EPM-1234 @type=Integration'
+```
+
+The outputted test element will look as follows:
+```xml
+<test name="test should behave like so" aid="EPM-DP-C1234" sid="EPM-1234" type="Integration" />
+```

--- a/index.js
+++ b/index.js
@@ -17,8 +17,41 @@ var INVALID_CHARACTERS = ['\u001b'];
 
 function configureDefaults(options) {
   debug(options);
-  options = options || {};
-  options = options.reporterOptions || {};
+
+  if (!options) {
+    options = {};
+  } else if (options.reporterOptions) {
+    options = options.reporterOptions;
+  } else {
+    /*
+     * Mocha parses mocharc files by flattening nested properties into
+     * top-level properties with period-delimited property names.
+     *
+     * Example .mocharc.json (abbreviated):
+     *
+     * {
+     *   "reporter": "mocha-xunit-reporter",
+     *   "reporterOptions": {
+     *     "mochaFile": "my-test-results.xml",
+     *   }
+     * }
+     *
+     * The resulting options object includes a property under the key
+     * `reporterOptions.mochaFile`, rather than including an object under key
+     * `reporterOptions`.
+     *
+     * To honor reporter options specified in these files, check for options
+     * prefixed with `reporterOptions.`.
+     */
+    options = Object.keys(options).reduce(function(reporterOptions, key) {
+      if (key.startsWith('reporterOptions.')) {
+        reporterOptions[key.substring('reporterOptions.'.length)] = options[key];
+      }
+
+      return reporterOptions;
+    }, {});
+  }
+
   options.mochaFile =
     options.mochaFile || process.env.MOCHA_FILE || 'test-results.xml';
   options.toConsole = !!options.toConsole;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-xunit-reporter",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A Mocha xunit reporter",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I ran into the same problem as [this issue](https://github.com/michaelleeallen/mocha-junit-reporter/issues/112) in `mocha-junit-reporter`; reporter options specified in a `.mocharc*` file were ignored. (More precisely, mocha provides the options to the reporter under a prefixed property name, rather than as nested objects. See the comment in `index.js` for an explicit example.)

Primary change: add support for mocharc files.
- Implementation adapted from the same behavior in `mocha-junit-reporter` ([see here](https://github.com/michaelleeallen/mocha-junit-reporter/blob/3d1909dbb37bd06b443dfcf2b881a0ff02251a65/index.js#L52-L56)).
- `mocha-junit-reporter` has otherwise deviated significantly from this repository; reaching parity would be a large undertaking.

README changes:
1. Reformat most of the documentation in a way that I hope is beneficial.
    - I know this adds to the burden of reviewing; apologies.
1. Add parameter types to the configuration options.
1. Document the magic `[hash]` behavior of the output file.

I tested this with
- Environment variable (for `MOCHA_FILE`)
- Command-line options (`--reporter-option mochaFile=...`)
- `.mocharc.js`
- `.mocharc.json`
- `.mocharc.yaml`
    - I have no prior experience configuring Mocha with YAML, but this appeared to work correctly.