### PR TITLE
Use valid values for results

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,14 +145,14 @@ function MochaXUnitReporter(runner, options) {
   this._runner.on(
     'pass',
     function(test) {
-      lastCollection().push(this.getTestData(test, 'passed'));
+      lastCollection().push(this.getTestData(test, 'Pass'));
     }.bind(this)
   );
 
   this._runner.on(
     'fail',
     function(test, err) {
-      lastCollection().push(this.getTestData(test, 'failed'));
+      lastCollection().push(this.getTestData(test, 'Fail'));
     }.bind(this)
   );
 
@@ -160,7 +160,7 @@ function MochaXUnitReporter(runner, options) {
     this._runner.on(
       'pending',
       function(test) {
-        var test = this.getTestData(test, 'skipped');
+        var test = this.getTestData(test, 'Skip');
         lastCollection().push(test);
       }.bind(this)
     );
@@ -210,7 +210,6 @@ MochaXUnitReporter.prototype.getTestData = function(test, status) {
       name = stripAnsi(tagResult.cleanTitle);
     }
   }
-
   var testCase = {
     test: [
       {
@@ -245,7 +244,7 @@ MochaXUnitReporter.prototype.getTestData = function(test, status) {
     });
   }
 
-  if (status === 'failed') {
+  if (status === 'Fail') {
     testCase.test.push({
       failure: [
         {
@@ -319,13 +318,13 @@ MochaXUnitReporter.prototype.getXml = function(collections) {
     _collAttr.skipped = 0;
 
     _cases.forEach(function(test) {
-      if (test.test[0]._attr.result == 'skipped') {
+      if (test.test[0]._attr.result == 'Skip') {
         _collAttr.skipped++;
       }
-      if (test.test[0]._attr.result == 'failed') {
+      if (test.test[0]._attr.result == 'Fail') {
         _collAttr.failed++;
       }
-      if (test.test[0]._attr.result == 'passed') {
+      if (test.test[0]._attr.result == 'Pass') {
         _collAttr.passed++;
       }
       _collAttr.time += test.test[0]._attr.time;

--- a/test/mocha-xunit-reporter-spec.js
+++ b/test/mocha-xunit-reporter-spec.js
@@ -291,7 +291,7 @@ describe('mocha-xunit-reporter', () => {
       runner.startSuite({ title: '', root: true, suites: [1], tests: [] });
       runner.fail({
         fullTitle: () => 'before all hook',
-      }, 'failed');
+      }, 'Fail');
       runner.end();
 
       expect(assembly[0].collection[0]._attr).to.have.property(
@@ -300,7 +300,7 @@ describe('mocha-xunit-reporter', () => {
       );
       expect(assembly[0].collection[1].test[0]._attr).to.have.property(
         'result',
-        'failed'
+        'Fail'
       );
     });
 

--- a/test/mock-results.js
+++ b/test/mock-results.js
@@ -38,7 +38,7 @@ module.exports = function(stats, options) {
                     _attr: {
                       name: 'Foo can weez the juice',
                       time: '0.001',
-                      result: 'passed'
+                      result: 'Pass'
                     }
                   }
                 ]
@@ -49,7 +49,7 @@ module.exports = function(stats, options) {
                     _attr: {
                       name: 'Bar can narfle the garthog',
                       time: '0.001',
-                      result: 'failed'
+                      result: 'Fail'
                     }
                   },
                   {
@@ -77,7 +77,7 @@ module.exports = function(stats, options) {
                     _attr: {
                       name: 'Baz can behave like a flandip',
                       time: '0.001',
-                      result: 'failed'
+                      result: 'Fail'
                     }
                   },
                   {
@@ -119,7 +119,7 @@ module.exports = function(stats, options) {
                     _attr: {
                       name: 'Another suite',
                       time: '0.004',
-                      result: 'passed'
+                      result: 'Pass'
                     }
                   }
                 ]
@@ -150,7 +150,7 @@ module.exports = function(stats, options) {
               _attr: {
                 name: 'Pending suite',
                 time: '0',
-                result: 'skipped'
+                result: 'Skip'
               }
             }
           ]


### PR DESCRIPTION
This changes "passed" to "Pass", "failed" to "Fail" and "skipped" to
"Skip", as per the [xunit documentation](https://xunit.net/docs/format-xml-v2)